### PR TITLE
sdm660: Disable RRO overlays

### DIFF
--- a/sdm660.mk
+++ b/sdm660.mk
@@ -27,13 +27,7 @@ PRODUCT_COMPATIBLE_PROPERTY_OVERRIDE := true
 
 # Overlays
 DEVICE_PACKAGE_OVERLAYS += \
-    $(LOCAL_PATH)/overlay \
-    $(LOCAL_PATH)/overlay-lineage
-
-PRODUCT_ENFORCE_RRO_TARGETS := *
-PRODUCT_ENFORCE_RRO_EXCLUDED_OVERLAYS += \
-    $(LOCAL_PATH)/overlay-lineage/lineage-sdk \
-    $(LOCAL_PATH)/overlay-lineage/packages/apps/Snap
+    $(LOCAL_PATH)/overlay 
 
 # Soong namespaces
 PRODUCT_SOONG_NAMESPACES += \


### PR DESCRIPTION
also nuke unwanted lineage overlays